### PR TITLE
Default to 1 minute interval for updateStatus

### DIFF
--- a/main.js
+++ b/main.js
@@ -339,7 +339,7 @@ class VwWeconnect extends utils.Adapter {
 
                                 this.updateInterval = setInterval(() => {
                                     this.updateStatus();
-                                }, this.config.interval * 60 * 1000);
+                                }, (this.config.interval || 1) * 60 * 1000);
 
                                 if (this.config.type !== "id" && this.config.type !== "skodae") {
                                     if (this.config.forceinterval > 0) {


### PR DESCRIPTION
I'm using the adapter outside ioBroker in my own private app.  I didn't first set the interval and in that case the adapter updates the status as fast as it can, flooding the VW servers and hits a rate limit very fast. 😅

This PR defaults to 1 minute update interval in case the interval has not been set in config.

