### PR TITLE
FIX: empty body causes VWV2 to break

### DIFF
--- a/main.js
+++ b/main.js
@@ -1546,7 +1546,7 @@ class VwWeconnect extends utils.Adapter {
                 return;
             }
             let method = "get";
-            let body = "";
+            let body = {};
             let url = this.replaceVarInUrl("https://msg.volkswagen.de/fs-car/usermanagement/users/v1/$type/$country/vehicles");
             let headers = {
                 "User-Agent": this.userAgent,
@@ -1627,7 +1627,7 @@ class VwWeconnect extends utils.Adapter {
                     followAllRedirects: true,
                     gzip: true,
                     json: true,
-                    body: body,
+                    ...(Object.keys(body).length && {body})
                 },
                 (err, resp, body) => {
                     if (err || (resp && resp.statusCode >= 400)) {


### PR DESCRIPTION
When the body is an empty string the API call fails for VWV2 cars.

Making this body conditional based on the length does work.