### PR TITLE
Fix EU Data Act polling interaction with VW ID updates

### DIFF
--- a/main.js
+++ b/main.js
@@ -362,9 +362,15 @@ class VwWeconnect extends utils.Adapter {
         this.getPersonalData().then(() => {
           this.getVehicles()
             .then(() => {
+              if (this.config.type === "id") {
+                this.log.debug(`VW ID classic flow: getVehicles returned ${this.vinArray.length} vehicle(s)`);
+              }
               if (this.config.type !== "go") {
                 this.vinArray.forEach((vin) => {
                   if (this.config.type === "id" || this.config.type === "audietron") {
+                    if (this.config.type === "id") {
+                      this.log.debug(`VW ID classic flow: fetching BFF status for ${vin}`);
+                    }
                     this.getHomeRegion(vin);
 
                     this.getIdStatus(vin).catch(() => {
@@ -1572,7 +1578,9 @@ class VwWeconnect extends utils.Adapter {
     } else if (this.config.type === "id") {
       // Periodischer Refresh: BFF-Status (selectivestatus, parking, …) plus
       // optional EU Data Act als ergänzende Quelle (15-min Datasets).
+      this.log.debug(`VW ID classic flow: scheduled update for ${this.vinArray.length} vehicle(s)`);
       this.vinArray.forEach((vin) => {
+        this.log.debug(`VW ID classic flow: fetching BFF status for ${vin}`);
         this.getIdStatus(vin).catch(() => {
           this.log.error("get id status Failed");
         });
@@ -3952,6 +3960,9 @@ class VwWeconnect extends utils.Adapter {
             forceIndex: true,
             makeStateWritableWithEnding: ["settings"],
           });
+          this.log.debug(
+            `VW ID classic flow: selectivestatus updated ${Object.keys(data).length} top-level field(s) for ${vin}`,
+          );
           this.setOtherStatesInChannelNull(vin + ".status.accessStatus", timestamp - 1000);
 
           if (this.config.rawJson) {
@@ -4000,8 +4011,17 @@ class VwWeconnect extends utils.Adapter {
           }
           this.log.debug(JSON.stringify(res.data));
           this.extractKeys(this, vin + ".parkingposition", res.data.data);
+          if (this.config.type === "id") {
+            this.log.debug(`VW ID classic flow: parkingposition updated for ${vin} (HTTP ${res.status})`);
+          }
         })
         .catch((error) => {
+          if (this.config.type === "id" && error && error.response) {
+            this.log.debug(
+              `VW ID classic flow: no parkingposition update for ${vin} (HTTP ${error.response.status})`,
+            );
+            return;
+          }
           this.log.debug(error);
           this.log.debug("No parkingposition found");
           //   error.response && this.log.error(JSON.stringify(error.response.data));

--- a/main.js
+++ b/main.js
@@ -49,6 +49,7 @@ class VwWeconnect extends utils.Adapter {
     this.vwrefreshTokenInterval = null;
     this.updateInterval = null;
     this.fupdateInterval = null;
+    this.euDataActInterval = null;
     this.refreshTokenTimeout = null;
 
     this.homeRegion = {};
@@ -7024,8 +7025,8 @@ class VwWeconnect extends utils.Adapter {
     // list endpoint every minute and only download when the newest filename
     // changes. That avoids the clock-skew / cold-start / overdue-drop edge
     // cases of trying to predict the exact drop time from createdOn.
-    if (this.updateInterval) clearInterval(this.updateInterval);
-    this.updateInterval = setInterval(() => {
+    if (this.euDataActInterval) clearInterval(this.euDataActInterval);
+    this.euDataActInterval = setInterval(() => {
       for (const vin of this.vinArray) {
         this.getEuDataActStatus(vin).catch((err) => {
           this.log.error(`EU Data Act status for ${vin} failed: ${err.message || err}`);
@@ -7284,6 +7285,7 @@ class VwWeconnect extends utils.Adapter {
       clearInterval(this.vwrefreshTokenInterval);
       clearInterval(this.updateInterval);
       clearInterval(this.fupdateInterval);
+      clearInterval(this.euDataActInterval);
       clearTimeout(this.refreshTokenTimeout);
       clearTimeout(this.refreshTimeout);
       clearTimeout(this.restartTimeout);

--- a/main.js
+++ b/main.js
@@ -7190,6 +7190,35 @@ class VwWeconnect extends utils.Adapter {
       if (newest.createdOn) {
         payload._dataset_created_on = newest.createdOn;
       }
+      await this.extendObjectAsync(vin + ".statuseudata", {
+        type: "channel",
+        common: {
+          name: "EU Data Act 15-min dataset",
+        },
+        native: {},
+      });
+      await this.extendObjectAsync(vin + ".statuseudata._dataset_name", {
+        type: "state",
+        common: {
+          name: "EU Data Act dataset name",
+          type: "string",
+          role: "text",
+          read: true,
+          write: false,
+        },
+        native: {},
+      });
+      await this.extendObjectAsync(vin + ".statuseudata._dataset_created_on", {
+        type: "state",
+        common: {
+          name: "EU Data Act dataset creation time",
+          type: "string",
+          role: "date",
+          read: true,
+          write: false,
+        },
+        native: {},
+      });
       await this.json2iob.parse(vin + ".statuseudata", payload, {
         forceIndex: true,
         channelName: "EU Data Act 15-min dataset",

--- a/main.js
+++ b/main.js
@@ -3984,10 +3984,26 @@ class VwWeconnect extends utils.Adapter {
         })
         .catch((error) => {
           if (error.response && error.response.status >= 500) {
-            this.log.info("Server not available. Please try again later:" + JSON.stringify(error.response.data));
+            if (this.config.type === "id") {
+              this.log.info(
+                "VW ID classic flow: selectivestatus server not available for " +
+                  vin +
+                  ": HTTP " +
+                  error.response.status +
+                  " " +
+                  JSON.stringify(error.response.data),
+              );
+            } else {
+              this.log.info("Server not available. Please try again later:" + JSON.stringify(error.response.data));
+            }
+            resolve();
             return;
           }
-          this.log.error("Fetching status failed");
+          if (this.config.type === "id") {
+            this.log.error("VW ID classic flow: selectivestatus failed for " + vin);
+          } else {
+            this.log.error("Fetching status failed");
+          }
           this.log.error(error);
           error && error.response && this.log.error(JSON.stringify(error.response.data));
           reject();

--- a/main.js
+++ b/main.js
@@ -7145,6 +7145,15 @@ class VwWeconnect extends utils.Adapter {
    */
   async getEuDataActStatus(vin) {
     if (!this.euDataAct) return;
+    this.euDataActBackoffUntil = this.euDataActBackoffUntil || {};
+    if (this.euDataActBackoffUntil[vin] && Date.now() < this.euDataActBackoffUntil[vin]) {
+      this.log.debug(
+        `EU Data Act: ${vin} portal backoff active until ${new Date(
+          this.euDataActBackoffUntil[vin],
+        ).toISOString()}`,
+      );
+      return;
+    }
     const identifier = await this._ensureEuDataActIdentifier(vin);
     if (!identifier) return;
     this.euDataActLastDataset = this.euDataActLastDataset || {};
@@ -7154,6 +7163,7 @@ class VwWeconnect extends utils.Adapter {
       // portal happily serves it every minute.
       const listStart = Date.now();
       const datasets = await this.euDataAct.listDatasets(vin, identifier);
+      delete this.euDataActBackoffUntil[vin];
       const contentDatasets = datasets.filter((d) => d && d.name && !d.name.endsWith("_no_content_found.zip"));
       const newest = contentDatasets.sort(
         (a, b) => String(b.createdOn || b.name).localeCompare(String(a.createdOn || a.name)),
@@ -7265,6 +7275,14 @@ class VwWeconnect extends utils.Adapter {
       // Identifier so the next cycle re-fetches metadata.
       if (/No files available/i.test(msg)) {
         this.log.debug(`EU Data Act: ${vin} no datasets emitted yet (data request just activated?)`);
+        return;
+      }
+      const serverError = msg.match(/HTTP (5\d\d)/);
+      if (serverError) {
+        this.euDataActBackoffUntil[vin] = Date.now() + 15 * 60 * 1000;
+        this.log.info(
+          `EU Data Act: portal temporarily unavailable for ${vin} (HTTP ${serverError[1]}), retry in 15min`,
+        );
         return;
       }
       if (/HTTP (?:404|400)/.test(msg)) {


### PR DESCRIPTION
This PR contains a few small fixes around the VW ID classic update flow and the optional EU Data Act polling.

Changes:
- create EU Data Act metadata state objects before writing `_dataset_*` values
- add debug logging for VW ID classic refresh diagnostics
- use a separate EU Data Act polling timer so it does not replace the regular adapter update interval
- add a short backoff for temporary EU Data Act portal HTTP 5xx errors
- handle temporary VW ID `selectivestatus` server errors without leaving the update flow hanging

The main functional fix is the separate EU Data Act timer. In my tests, the classic VW ID updates continued to run periodically after this change.