### PR TITLE
Fix repeated errors for unsupported Skoda endpoints

### DIFF
--- a/lib/isUnsupportedSkodaEndpoint.js
+++ b/lib/isUnsupportedSkodaEndpoint.js
@@ -1,0 +1,27 @@
+"use strict";
+
+/**
+ * Detect endpoint responses which mean that a service is not available for the
+ * vehicle, rather than a temporary backend outage.
+ *
+ * @param {{path: string, postfix: string}} endpoint API endpoint descriptor
+ * @param {number} statusCode HTTP response status
+ * @param {unknown} responseData HTTP response body
+ * @returns {boolean} whether the endpoint should be ignored until adapter restart
+ */
+function isUnsupportedSkodaEndpoint(endpoint, statusCode, responseData) {
+  if (statusCode === 400 && endpoint.path.startsWith("fueling/")) {
+    return true;
+  }
+
+  if (statusCode !== 500 || !JSON.stringify(responseData).includes("Internal server error")) {
+    return false;
+  }
+
+  return (
+    (endpoint.path === "fueling/sessions" && endpoint.postfix === "/latest") ||
+    (endpoint.path === "charging" && endpoint.postfix === "/settings")
+  );
+}
+
+module.exports = isUnsupportedSkodaEndpoint;

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@
 // The adapter-core module gives you access to the core ioBroker functions
 // you need to create an adapter
 const utils = require("@iobroker/adapter-core");
+const isUnsupportedSkodaEndpoint = require("./lib/isUnsupportedSkodaEndpoint");
 
 const request = require("request");
 const qs = require("qs");
@@ -4824,6 +4825,16 @@ class VwWeconnect extends utils.Adapter {
             }
             if (error.response.status === 412) {
               this.log.debug(JSON.stringify(error.response.data));
+              return;
+            }
+            if (
+              isUnsupportedSkodaEndpoint(status, error.response.status, error.response.data)
+            ) {
+              this.log.debug("Vehicle is not supporting " + status.path + " " + status.postfix);
+              if (!this.ignoredPaths[vin]) {
+                this.ignoredPaths[vin] = [];
+              }
+              this.ignoredPaths[vin].push(status.path + status.postfix);
               return;
             }
             if (error.response.status === 404 || error.response.status === 403) {

--- a/test/unit/isUnsupportedSkodaEndpoint.test.js
+++ b/test/unit/isUnsupportedSkodaEndpoint.test.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const { expect } = require("chai");
+const isUnsupportedSkodaEndpoint = require("../../lib/isUnsupportedSkodaEndpoint");
+
+describe("isUnsupportedSkodaEndpoint", () => {
+  it("caches validation errors for unsupported fueling endpoints", () => {
+    expect(
+      isUnsupportedSkodaEndpoint({ path: "fueling/sessions", postfix: "/state" }, 400, {
+        message: "Validation failed",
+      }),
+    ).to.equal(true);
+  });
+
+  it("caches the observed internal error for fueling latest", () => {
+    expect(
+      isUnsupportedSkodaEndpoint({ path: "fueling/sessions", postfix: "/latest" }, 500, "Internal server error"),
+    ).to.equal(true);
+  });
+
+  it("caches the observed internal error for charging settings", () => {
+    expect(
+      isUnsupportedSkodaEndpoint({ path: "charging", postfix: "/settings" }, 500, "Internal server error"),
+    ).to.equal(true);
+  });
+
+  it("keeps temporary server failures visible for other endpoints", () => {
+    expect(
+      isUnsupportedSkodaEndpoint({ path: "charging", postfix: "" }, 500, "Internal server error"),
+    ).to.equal(false);
+  });
+
+  it("does not hide authentication or rate-limit errors", () => {
+    const endpoint = { path: "fueling/sessions", postfix: "" };
+    expect(isUnsupportedSkodaEndpoint(endpoint, 401, "Unauthorized")).to.equal(false);
+    expect(isUnsupportedSkodaEndpoint(endpoint, 429, "Too many requests")).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary

- cache HTTP 400 responses from Skoda fueling endpoints as unsupported for the current adapter session
- cache the observed HTTP 500 Internal server error from fueling/sessions/latest and charging/settings only
- keep authentication, rate-limit and temporary server failures on all other endpoints visible
- add focused unit coverage for the classifier

## Live verification

Tested with a Skoda Enyaq on adapter 0.9.6. Before the change, all four fueling endpoints and charging/settings logged on every 15-minute poll. After restart, login and vehicle polling remain successful and those unsupported endpoints no longer repeat.

## Tests

- npx mocha test/unit/isUnsupportedSkodaEndpoint.test.js: 5 passing
- npx mocha test/package --exit: 43 passing
- npm run lint: passing

Note: the repository's existing npm test script currently fails before running tests because current Mocha no longer supports the configured --opts flag.

Fixes #443
Fixes #356