### PR TITLE
fix: pass VIN when creating longitude position channel

### DIFF
--- a/main.js
+++ b/main.js
@@ -8441,7 +8441,7 @@ class VwWeconnect extends utils.Adapter {
   }
 
   async setLongitude(vin, value) {
-    await this.setPositionChanel();
+    await this.setPositionChanel(vin);
     await this.extendObjectAsync(vin + ".position.longitudeConv", {
       type: "state",
       common: {


### PR DESCRIPTION
## Summary
- pass the vehicle VIN to setPositionChanel from setLongitude
- prevent creation of the stray vw-connect.<instance>.undefined.position channel
- keep longitude and geohash updates scoped to the correct vehicle

## Root cause
setLatitude correctly called setPositionChanel(vin), while setLongitude called it without the VIN. String interpolation therefore created an undefined.position object whenever longitude was processed first or independently.

## Tests
- npm run test:package (43 passing)
- npm run lint -- --no-warn-ignored
- node --check main.js
- git diff --check

Fixes #431